### PR TITLE
parseでのarrayのハンドリングをやめた

### DIFF
--- a/lib/deserialize.js
+++ b/lib/deserialize.js
@@ -18,9 +18,11 @@ function deserialize (serialized, options = {}) {
   } = options
 
   let payload = JSON.parse(serialized)
-
-  let meta = has(payload, metaPointer) && get(payload, metaPointer)
-  remove(payload, metaPointer)
+  let hasMeta = has(payload, metaPointer)
+  let meta = hasMeta && get(payload, metaPointer)
+  if (hasMeta) {
+    remove(payload, metaPointer)
+  }
   return parse(payload, meta, { converters })
 }
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -10,9 +10,6 @@ const defaultConverters = require('./converters')
 
 /** @lends parse */
 function parse (payload, meta, options = {}) {
-  if (Array.isArray(payload)) {
-    return payload.map((data) => parse(data, meta, options))
-  }
   let { converters = defaultConverters } = options
   switch (typeof payload) {
     case 'object':

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   "homepage": "https://github.com/realglobe-Inc/sg-serializer#readme",
   "dependencies": {
     "co": "^4.6.0",
-    "json-pointer": "^0.5.0"
+    "json-pointer": "^0.6.0"
   },
   "devDependencies": {
-    "ababel": "^1.1.2",
-    "ababel-es2015": "^1.0.6",
-    "amocha": "^1.0.14",
+    "ababel": "^2.0.1",
+    "ababel-es2015": "^2.0.1",
+    "amocha": "^2.0.0",
     "ape-doc": "^2.0.4",
     "ape-formatting": "^1.0.2",
     "ape-releasing": "^4.0.4",

--- a/test/deserialize_test.js
+++ b/test/deserialize_test.js
@@ -5,7 +5,7 @@
 'use strict'
 
 const deserialize = require('../lib/deserialize.js')
-const assert = require('assert')
+const { deepEqual } = require('assert')
 const co = require('co')
 
 describe('deserialize', function () {
@@ -21,7 +21,7 @@ describe('deserialize', function () {
 
   it('Deserialize', () => co(function * () {
     let deserialized = deserialize('[{"foo": "bar"}]')
-    assert.deepEqual(deserialized, [ { foo: 'bar' } ])
+    deepEqual(deserialized, [ { foo: 'bar' } ])
   }))
 })
 

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -5,7 +5,7 @@
 'use strict'
 
 const parse = require('../lib/parse.js')
-const assert = require('assert')
+const { ok, equal, deepEqual } = require('assert')
 const co = require('co')
 
 describe('parse', function () {
@@ -26,15 +26,26 @@ describe('parse', function () {
         'bar',
         'baz'
       ])
-      assert.deepEqual(parsed, [ 'foo', 'bar', 'baz' ])
+      deepEqual(parsed, [ 'foo', 'bar', 'baz' ])
     }
     {
       let parsed = parse({
         foo: 'bar',
         baz: new Date()
       })
-      assert.ok(parsed.foo)
-      assert.ok(parsed.baz)
+      ok(parsed.foo)
+      ok(parsed.baz)
+      ok(parsed.baz instanceof Date)
+    }
+
+    {
+      let parsed = parse([ {
+        foo: 'bar',
+        baz: new Date()
+      } ])
+      ok(parsed[ 0 ].foo)
+      ok(parsed[ 0 ].baz)
+      ok(parsed[ 0 ].baz instanceof Date)
     }
   }))
 })

--- a/test/serialize_test.js
+++ b/test/serialize_test.js
@@ -38,7 +38,7 @@ describe('serialize', function () {
       indent: 2
     })
     assert.ok(serialized)
-    console.log(serialized)
+    // console.log(serialized)
     assert.equal(typeof serialized, 'string')
 
     let d = deserialize(serialized)


### PR DESCRIPTION
actorから配列で返却した時にcaller側の型復元処理で落ちる問題があったので直した。