### PR TITLE
parseすると配列がオブジェクトになる問題を修正した

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -8,23 +8,38 @@
 const { get, set } = require('json-pointer')
 const defaultConverters = require('./converters')
 
+const parseObject = (payload, meta, converters) => {
+  payload = Object.assign({}, payload)
+  for (let pointer of Object.keys(meta || {})) {
+    let typeName = meta[ pointer ]
+    let converter = converters[ typeName ]
+    if (!converter) {
+      throw new Error(`[sg-serializer] Unknown type: ${typeName} `)
+    }
+    let value = get(payload, pointer)
+    set(payload, pointer, converter.parse(value))
+  }
+  return payload
+}
+
 /** @lends parse */
 function parse (payload, meta, options = {}) {
   let { converters = defaultConverters } = options
-  switch (typeof payload) {
+  let type = Array.isArray(payload) ? 'array' : typeof payload
+
+  switch (type) {
     case 'object':
-    case 'function':
-      payload = Object.assign({}, payload)
-      for (let pointer of Object.keys(meta || {})) {
-        let typeName = meta[ pointer ]
-        let converter = converters[ typeName ]
-        if (!converter) {
-          throw new Error(`[sg-serializer] Unknown type: ${typeName} `)
-        }
-        let value = get(payload, pointer)
-        set(payload, pointer, converter.parse(value))
-      }
-      return payload
+    case 'function': {
+      let parsedPayload = parseObject(payload, meta, converters)
+      return parsedPayload
+    }
+    case 'array': {
+      let { length } = payload
+      let parsedPayload = parseObject(payload, meta, converters)
+      parsedPayload.length = length
+      parsedPayload = Array.from(parsedPayload)
+      return parsedPayload
+    }
     default:
       return payload
   }

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -43,6 +43,7 @@ describe('parse', function () {
         foo: 'bar',
         baz: new Date()
       } ])
+      ok(Array.isArray(parsed))
       ok(parsed[ 0 ].foo)
       ok(parsed[ 0 ].baz)
       ok(parsed[ 0 ].baz instanceof Date)


### PR DESCRIPTION
```js
let parsed = parse([ {
  foo: 'bar',
  baz: new Date()
} ])
ok(Array.isArray(parsed))
```
これが通るようにした。